### PR TITLE
Fix no-confirmation .deletePaths call.

### DIFF
--- a/lib/permanent-delete.js
+++ b/lib/permanent-delete.js
@@ -22,7 +22,7 @@ function deactivate() {
 
 function deleteCommand() {
   var treeView = atom.packages.getActivePackage('tree-view');
-  console.log(treeView);
+  // console.log(treeView);
   if(!treeView) return;
   treeView = treeView.mainModule.createView();
   selectedPaths = treeView.selectedPaths();

--- a/lib/permanent-delete.js
+++ b/lib/permanent-delete.js
@@ -38,7 +38,7 @@ function deleteCommand() {
       }
     });
   } else {
-    this.deleteSelectedPaths(selectedPaths);
+    deletePaths(selectedPaths);
   }
 }
 


### PR DESCRIPTION
Calls the correct function in cases where the user has disabled deletion confirmation. Prior to this patch, calling the undefined `this.deleteSelectedPaths()` method caused Atom to throw a hissy fit. Thanks for your work on this package!
