### PR TITLE
Update permanent-delete.js

### DIFF
--- a/lib/permanent-delete.js
+++ b/lib/permanent-delete.js
@@ -1,18 +1,22 @@
-'use babel';
-import fs from 'fs-plus';
+"use babel";
+import fs from "fs-plus";
 
 var config = {
   confirmDelete: {
-    description: 'Confirm dialog before deleting files',
-    type: 'boolean',
-    default: true
-  }
+    description: "Confirm dialog before deleting files",
+    type: "boolean",
+    default: true,
+  },
 };
 
 var disposable;
 
 function activate() {
-  disposable = atom.commands.add('atom-workspace', 'permanent-delete:delete', deleteCommand);
+  disposable = atom.commands.add(
+    "atom-workspace",
+    "permanent-delete:delete",
+    deleteCommand
+  );
 }
 
 function deactivate() {
@@ -21,30 +25,34 @@ function deactivate() {
 }
 
 function deleteCommand() {
-  var treeView = atom.packages.getActivePackage('tree-view');
-  if(!treeView) return;
+  var treeView = atom.packages.getActivePackage("tree-view");
+  if (!treeView) return;
   treeView = treeView.mainModule.getTreeViewInstance();
   selectedPaths = treeView.selectedPaths();
-  if(atom.config.get('permanent-delete.confirmDelete')) {
-    atom.confirm({
-      message: `Are you sure you want to delete the selected ${selectedPaths > 1 ? 'items' : 'item'}?`,
-      detailedMessage: `You are deleting: \n${selectedPaths.join('\n')}`,
-      buttons:{
-        'Delete permanently': function() {
+  if (atom.config.get("permanent-delete.confirmDelete")) {
+    atom.confirm(
+      {
+        message: `Are you sure you want to delete the selected ${
+          selectedPaths > 1 ? "items" : "item"
+        }?`,
+        detailedMessage: `You are deleting: \n${selectedPaths.join("\n")}`,
+        buttons: ["Delete permanently", "Cancel"],
+      },
+      function (result) {
+        if (result === 0) {
           deletePaths(selectedPaths);
-        },
-        'Cancel': null
+        }
       }
-    });
+    );
   } else {
     deletePaths(selectedPaths);
   }
 }
 
 function deletePaths(paths) {
-  for(let path of paths) {
+  for (let path of paths) {
     fs.remove(path, function(){});
   }
 }
 
-export {config, activate, deactivate};
+export { config, activate, deactivate };


### PR DESCRIPTION
Due to update to Electron 6, atom.confirm's API has changed. I've updated the thing to use the new API. Also reformatted because I'm lazy. Sorry about that.